### PR TITLE
docs: add part 2 planning, tasks and responsibilities

### DIFF
--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -1,96 +1,176 @@
-# Planeación del Proyecto — Admin de Redes Parte 1
+# Planeación del Proyecto — Admin de Redes Parte 2
 
-## Descripción
+## Estado del proyecto
 
-Script interactivo en Bash que permite a un administrador de sistemas gestionar usuarios, grupos y visualizar procesos desde un menú de texto, verificando previamente que quien lo ejecuta tiene privilegios de root.
+### Parte 1 — Completada ✓
 
-## Funcionalidades del script
+| Módulo | Archivo | Responsable | Estado |
+|--------|---------|-------------|--------|
+| Helpers compartidos | `src/lib/utils.sh` | Anthony | ✓ Mergeado |
+| Gestión de usuarios | `src/users.sh` | Diego | ✓ Mergeado |
+| Gestión de grupos | `src/groups.sh` | Imanol | ✓ Mergeado |
+| Gestión de procesos | `src/processes.sh` | Osvaldo | ✓ Mergeado |
+| Core / entrypoint | `main.sh` | Axel | ✓ Mergeado |
 
-### Verificación de acceso
-- Si el proceso se ejecuta como root → muestra el menú principal.
-- Si NO es root → imprime `Acceso denegado` y termina con código de salida 1.
+### Parte 2 — En desarrollo
 
-### Menú 1 — Usuarios
-| Opción         | Comando(s) Linux                          |
-|----------------|-------------------------------------------|
-| Alta           | `useradd`, `passwd` / `chpasswd`          |
-| Baja           | `userdel` / `userdel -r`                  |
-| Consulta       | `id`, `getent passwd`, `chage -l`         |
-| Modificaciones | `usermod`, `chage`, `passwd`              |
+Agrega 3 nuevas opciones al menú principal y corrige observaciones de la primera revisión.
 
-Modificaciones incluye: fecha de caducidad, directorio home, estado de cuenta (lock/unlock), shell.
+---
 
-### Menú 2 — Grupos
-| Opción         | Comando(s) Linux                          |
-|----------------|-------------------------------------------|
-| Alta           | `groupadd`                                |
-| Baja           | `groupdel`                                |
-| Consulta       | `getent group`                            |
-| Modificaciones | `groupmod`, `gpasswd`                     |
+## Correcciones de Parte 1 (PC-1)
 
-Modificaciones incluye: renombrar grupo, agregar/quitar miembros.
+Observaciones recibidas en la primera revisión del proyecto:
 
-### Menú 3 — Procesos del usuario consultado
-| Vista         | Comando                                   |
-|---------------|-------------------------------------------|
-| Snapshot      | `ps aux --user <usuario>`                 |
-| Tiempo real   | `top -u <usuario>`                        |
+1. **Listar usuarios/grupos antes de operar** — en baja, consulta y modificación de usuarios y grupos, el operador debe ver la lista de recursos disponibles en lugar de escribir el nombre a ciegas.
+2. **Opción Root en procesos** — agregar opción 3 en el submenú de procesos que muestre directamente los procesos de root sin solicitar nombre.
+3. **Diseño profesional** — mejorar la apariencia visual del script usando herramientas TUI disponibles en AlmaLinux 9.
+
+**Solución de diseño adoptada: `whiptail`**
+
+`whiptail` viene preinstalada en AlmaLinux 9 como parte del paquete `newt`. No requiere instalación adicional ni agregar dependencias al proyecto. Permite:
+
+- `--menu` → listas seleccionables de usuarios y grupos
+- `--inputbox` → campos de entrada con ventana visual
+- `--yesno` → confirmaciones con botones Sí/No
+- `--msgbox` → mensajes con ventana
+
+Todas las correcciones van en un solo PR asignado a Axel.
+
+---
+
+## Parte 2 — Nuevas funcionalidades
+
+### Opción 4 — Automatización de tareas
+
+| Sub-opción | Herramienta | Descripción |
+|------------|-------------|-------------|
+| 1) Cron | `crontab` | Programar tarea recurrente (diaria, semanal, etc.) |
+| 2) At | `at` | Programar tarea puntual en fecha/hora específica |
+
+El módulo pide al usuario la tarea a ejecutar y la fecha/hora de ejecución.
+
+### Opción 5 — Respaldo de información
+
+| Sub-opción | Herramienta | Descripción |
+|------------|-------------|-------------|
+| 1) Tar-gzip | `tar -czf` | Comprimir carpeta con gzip (.tar.gz) |
+| 2) Tar-bzip2 | `tar -cjf` | Comprimir carpeta con bzip2 (.tar.bz2) |
+
+El módulo pide la carpeta origen y la ruta de destino del respaldo.
+
+### Opción 6 — Seguridad / Monitoreo
+
+| Sub-opción | Herramienta | Modo |
+|------------|-------------|------|
+| a) Nagios | `nagios` + `httpd` | Abre el dashboard en el navegador |
+| b) Wireshark | `wireshark` | Lanza la interfaz gráfica |
+| c) Nmap / iftop | `nmap` / `iftop` | Ejecuta en la misma terminal |
 
 ---
 
 ## Decisiones técnicas
 
-### Plataforma: AlmaLinux 9
+### Instalación de herramientas de seguridad
 
-El proyecto utiliza exclusivamente **AlmaLinux 9** por las siguientes razones:
+Las herramientas del módulo de seguridad (Nagios, Wireshark, Nmap, iftop) requieren instalación previa en cada máquina. La docente advirtió sobre problemas de compatibilidad con instalaciones desde código fuente en AlmaLinux 9.
 
-1. **Alineación con los materiales de clase.** La asignatura utilizará herramientas como Nagios, Cacti y OpenManage. Los materiales del profesor, rutas de instalación y comandos de configuración están basados en RHEL/AlmaLinux. Seguir la misma distribución evita divergencias en los laboratorios.
+**Solución adoptada:** instalación vía repositorio EPEL, que resuelve automáticamente los plugins y dependencias sin necesidad de compilar desde fuente ni cambiar la versión del sistema operativo.
 
-2. **Soporte nativo de Dell OpenManage (OMSA).** OpenManage Server Administrator tiene soporte oficial y paquetes RPM mantenidos por Dell para RHEL 8/9 y sus clones (AlmaLinux, Rocky). En distribuciones Debian/Ubuntu, la instalación requiere repositorios no oficiales y pasos adicionales de configuración.
+```bash
+# Los pasos clave del script de instalación
+dnf config-manager --set-enabled crb
+dnf install -y epel-release
+setenforce 0  # SELinux permissive (requerido por Nagios)
+dnf install -y nagios nagios-common nagios-plugins-all nrpe wireshark-qt nmap iftop
+```
 
-3. **Entorno empresarial RHEL-compatible.** AlmaLinux 9 es un clon binario de RHEL 9, el estándar de facto en entornos corporativos de administración de servidores Linux.
+**Versión del sistema:** AlmaLinux 9.7 — no se requiere downgrade.
 
-4. **Nota sobre Cacti y Nagios.** Para ser exactos: tanto Cacti como Nagios Core funcionan en Debian/Ubuntu sin diferencias significativas. El argumento real para usar AlmaLinux en este caso es la coherencia con el entorno de clase, no una incompatibilidad técnica.
+Osvaldo crea `scripts/install_security.sh` que el equipo completo ejecuta antes de hacer la demo. Este script va en su mismo PR de automatización.
 
-### Bash en lugar de Python u otro lenguaje
+### whiptail como capa de diseño
 
-El script utiliza comandos del sistema (`useradd`, `groupmod`, `chage`, etc.) directamente sin capas de abstracción. Bash es el lenguaje natural para este tipo de administración de sistemas y no requiere instalar intérpretes adicionales.
+Las funciones de whiptail se agregan a `src/lib/utils.sh` como helpers nuevos. Las funciones existentes (`msg_ok`, `msg_err`, etc.) se mantienen sin cambios para no romper compatibilidad con los módulos de Parte 2 que se desarrollan en paralelo.
 
----
+### Módulos nuevos son completamente independientes
 
-## Dependencias del sistema
-
-Declaradas en `deps.txt`. Todos los paquetes están preinstalados en una instalación mínima de AlmaLinux 9.
-
-| Paquete        | Comandos que provee                                    |
-|----------------|--------------------------------------------------------|
-| `shadow-utils` | `useradd`, `userdel`, `usermod`, `groupadd`, `groupdel`, `chage`, `passwd` |
-| `procps-ng`    | `ps`, `top`                                            |
-| `coreutils`    | `id`, `cut`, `sort`, `grep`                            |
-| `util-linux`   | `getopt`, utilidades generales                         |
-| `glibc-common` | `getent`                                               |
-
-Verificar con: `bash setup.sh`
+`automation.sh`, `backup.sh` y `security.sh` son archivos nuevos que no tocan nada de Parte 1. Solo `main.sh` los integra al final (PR de Anthony). Esto garantiza trabajo en paralelo sin bloqueos.
 
 ---
 
-## Supuestos técnicos
+## Estructura final del repositorio
 
-- El script siempre se ejecuta en una sesión de terminal interactiva.
-- El sistema tiene `bash` en `/usr/bin/env bash` (AlmaLinux 9: `/bin/bash`, enlazado).
-- SELinux puede estar en modo `enforcing` en AlmaLinux 9. Si se presentan problemas de permisos con comandos de administración, verificar con `getenforce`.
-- No se asume que existe un entorno gráfico ni `sudo` configurado; se documenta uso directo como root.
+```
+admin-redes/
+├── README.md
+├── main.sh                      ← P2-INT Anthony · opciones 4/5/6 + whiptail menú
+├── setup.sh
+├── deps.txt                     ← actualizar con nuevas dependencias
+├── src/
+│   ├── lib/
+│   │   └── utils.sh             ← PC-1 Axel · nuevas funciones whiptail
+│   ├── users.sh                 ← PC-1 Axel · listar usuarios + whiptail
+│   ├── groups.sh                ← PC-1 Axel · listar grupos + whiptail
+│   ├── processes.sh             ← PC-1 Axel · opción 3 Root
+│   ├── automation.sh            ← P2-1 Osvaldo · NUEVO
+│   ├── backup.sh                ← P2-2 Imanol · NUEVO
+│   └── security.sh              ← P2-3 Diego · NUEVO
+├── scripts/
+│   └── install_security.sh      ← P2-1 Osvaldo · NUEVO
+├── tests/
+│   ├── test_utils.sh
+│   ├── test_groups.sh
+│   ├── test_processes.sh
+│   └── test_users.sh
+└── docs/
+    ├── PLANNING.md              ← Parte 1
+    ├── PLANNING_P2.md           ← estás aquí
+    ├── RESPONSIBILITIES.md      ← Parte 1
+    ├── RESPONSIBILITIES_P2.md
+    ├── TASKS.md                 ← Parte 1
+    ├── TASKS_P2.md
+    ├── COLLABORATION_RULES.md
+    └── MANUAL_TESTS.md
+```
 
 ---
 
-## Estructura de módulos
+## Dependencias entre PRs
 
-| Módulo             | Archivo             | PR   | Depende de     |
-|--------------------|---------------------|------|----------------|
-| Helpers compartidos| `src/lib/utils.sh`  | #1   | ninguno        |
-| Entrypoint / core  | `main.sh`           | #2   | todos los demás|
-| Gestión usuarios   | `src/users.sh`      | #3   | #1 utils       |
-| Gestión grupos     | `src/groups.sh`     | #4   | #1 utils       |
-| Procesos           | `src/processes.sh`  | #5   | #1 utils       |
+```
+PC-1 (Axel correcciones)     → merge primero (día 3)
+                               Modifica utils.sh — los nuevos módulos
+                               pueden usar sus helpers una vez mergeado.
 
-Ver orden de merge en `docs/RESPONSIBILITIES.md`.
+P2-1 (Osvaldo automatización) → paralelo, sin dependencias
+P2-2 (Imanol respaldo)        → paralelo, sin dependencias
+P2-3 (Diego seguridad)        → paralelo, requiere install_security.sh
+                               de Osvaldo ejecutado en la máquina
+
+P2-INT (Anthony integración)  → merge último (día 5)
+                               Sourcéa los 3 nuevos módulos en main.sh
+                               y agrega las opciones 4/5/6 al menú.
+```
+
+**Nota para Diego:** el módulo de seguridad asume que `scripts/install_security.sh`
+de Osvaldo ya se ejecutó en la máquina. Si una herramienta no está instalada,
+el módulo muestra `msg_err` con instrucción de correr el script.
+
+---
+
+## Nuevas dependencias del sistema
+
+A agregar en `deps.txt`:
+
+| Paquete | Proveedor | Necesario para |
+|---------|-----------|----------------|
+| `at` | base | Automatización puntual |
+| `cronie` | base | Cron (puede ya estar) |
+| `tar` | base | Respaldos |
+| `nagios` | EPEL | Monitoreo |
+| `nagios-plugins-all` | EPEL | Monitoreo |
+| `nrpe` | EPEL | Monitoreo |
+| `wireshark-qt` | base | Captura de tráfico |
+| `nmap` | base | Escaneo de red |
+| `iftop` | EPEL | Monitor de tráfico en tiempo real |

--- a/docs/RESPONSIBILITIES.md
+++ b/docs/RESPONSIBILITIES.md
@@ -1,105 +1,94 @@
-# Responsabilidades del Equipo
+# Responsabilidades del Equipo — Parte 2
 
 ## Asignaciones
 
-| PR  | Rama feature              | Archivo             | Responsable | Prioridad |
-|-----|---------------------------|---------------------|-------------|-----------|
-| #1  | `feat/utils-lib`          | `src/lib/utils.sh`  | Antonio     | ALTA      |
-| #2  | `feat/core-entrypoint`    | `main.sh`           | Axel        | ALTA      |
-| #3  | `feat/users-module`       | `src/users.sh`      | Diego       | NORMAL    |
-| #4  | `feat/groups-module`      | `src/groups.sh`     | Imanol      | NORMAL    |
-| #5  | `feat/processes-module`   | `src/processes.sh`  | Osvaldo     | NORMAL    |
+| PR | Rama | Archivo(s) | Responsable | Prioridad |
+|----|------|-----------|-------------|-----------|
+| PC-1 | `feat/part1-corrections` | `utils.sh`, `users.sh`, `groups.sh`, `processes.sh` | Axel | ALTA — merge primero |
+| P2-1 | `feat/automation-module` | `src/automation.sh`, `scripts/install_security.sh` | Osvaldo | NORMAL |
+| P2-2 | `feat/backup-module` | `src/backup.sh` | Imanol | NORMAL |
+| P2-3 | `feat/security-module` | `src/security.sh` | Diego | NORMAL |
+| P2-INT | `feat/part2-integration` | `main.sh`, `deps.txt` | Anthony | ALTA — merge último |
 
-Para el detalle completo de qué implementar en cada PR (funciones, casos a manejar y cómo probarlo) → [`docs/TASKS.md`](TASKS.md)
+> Llenar con nombres completos si se requiere para la entrega formal.
+
+Para el detalle de qué implementar en cada PR → [`docs/TASKS_P2.md`](TASKS_P2.md)
 
 ---
 
 ## Dependencias entre PRs
 
-### ¿Hay PRs que deben esperar a otros?
+**¿Hay PRs que bloquean a otros?**
 
-**Durante el desarrollo (coding): NO.** Cada miembro puede codificar de forma completamente independiente desde el domingo porque `develop` ya contiene los stubs con las firmas de todas las funciones.
+Durante el desarrollo (coding): **NO.** Todos trabajan en archivos distintos desde el día 1.
 
-**Durante el merge: SÍ.** Existe un orden obligatorio de merge a `develop`:
+Durante el merge: **SÍ**, existe un orden obligatorio:
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│  ORDEN DE MERGE (no modificar esta secuencia)            │
-│                                                          │
-│  1. PR #1 (utils/lib)      ← DEBE ser el primero        │
-│     └─ Sin utils, los demás módulos no tienen helpers   │
-│                                                          │
-│  2. PR #3, #4, #5          ← en cualquier orden        │
-│     (usuarios, grupos, procesos)                         │
-│                                                          │
-│  3. PR #2 (core/entrypoint) ← DEBE ser el último        │
-│     └─ Sourcéa todos los módulos; si alguno no está     │
-│        en develop, el script falla al cargar             │
-└──────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  ORDEN DE MERGE                                             │
+│                                                             │
+│  1. PC-1  (Axel correcciones)    ← PRIMERO                 │
+│     └─ Modifica utils.sh con helpers whiptail               │
+│        Los demás pueden usarlos tras el merge               │
+│                                                             │
+│  2. P2-1, P2-2, P2-3            ← en cualquier orden       │
+│     (automatización, respaldo, seguridad)                   │
+│                                                             │
+│  3. P2-INT (Anthony integración) ← ÚLTIMO                  │
+│     └─ Sourcéa todos los módulos en main.sh                 │
+└─────────────────────────────────────────────────────────────┘
 ```
 
-### Implicaciones por persona
-
-**PR #1 (utils/lib) — Responsabilidad crítica:**  
-Aunque puedes desarrollar durante el fin de semana en paralelo con todos, tu módulo es el primero que se debe revisar y mergear. El **lunes por la mañana** es la meta para que el resto del equipo pueda hacer pruebas de integración completas. Si te bloqueas en alguna función, avisa al grupo lo antes posible.
-
-**PR #2 (core/entrypoint) — Merge al final:**  
-El titular del PR #2 (lead del proyecto) mergea de último porque su archivo fuente todos los demás módulos. Durante el desarrollo del sábado/domingo, puede avanzar en la lógica del menú; la integración final se hace el martes.
-
-**PRs #3, #4, #5 — Independientes entre sí:**  
-No se bloquean entre ellos. Pueden abrirse como PRs a develop desde el lunes y mergearse en cualquier orden.
+**Nota sobre seguridad (Diego):**
+El módulo `security.sh` requiere que `scripts/install_security.sh` (de Osvaldo)
+ya se haya ejecutado en la máquina para poder probar Nagios, Wireshark y Nmap.
+Coordinar con Osvaldo antes de hacer pruebas funcionales.
 
 ---
 
-## Cronograma de merge sugerido
+## Cronograma
 
-| Día       | Actividad de merge                                     |
-|-----------|--------------------------------------------------------|
-| Lun 4 may | Revisar y mergear PR #1 (utils) → develop              |
-| Mar 5 may | Revisar y mergear PR #3, #4, #5 (en paralelo) → develop|
-| Mar 5 may | Revisar y mergear PR #2 (core) → develop               |
-| Mar 5 may | Prueba de integración en develop                       |
-| Mar 5 may | Merge develop → main (solo el lead)                    |
+| Fecha | Actividad |
+|-------|-----------|
+| Dom 10 may | Crear ramas, subir stubs, todo el equipo inicia coding |
+| Lun 11 may | Coding — Axel termina whiptail; resto avanza módulos |
+| Mar 12 may | Coding — todos abren PRs hacia develop |
+| Mié 13 may | Anthony revisa PC-1 y lo mergea; revisa P2-1, P2-2, P2-3 |
+| Jue 14 may | Mergear P2-1, P2-2, P2-3 → develop |
+| Vie 15 may | Anthony mergea P2-INT → develop; prueba integración completa |
+| Vie 15 may | Merge develop → main (entrega final Parte 2) |
+
+**Rol de Anthony durante días 2-3:**
+Mientras el equipo codifica, Anthony revisa los PRs que se vayan abriendo.
+No empieza a codificar P2-INT hasta que los 4 PRs anteriores estén en develop.
 
 ---
 
 ## Criterios de revisión para cada PR
 
-El revisor es **responsable de garantizar** que el código funciona correctamente antes de aprobar. No basta con leer el código — hay que ejecutarlo.
+El revisor (Anthony) verifica antes de aprobar:
 
-### Verificación obligatoria antes de aprobar
+- [ ] `bash -n <archivo>` sin errores de sintaxis
+- [ ] `source src/lib/utils.sh; source <archivo>` sin errores de runtime
+- [ ] Funciones con nombres correctos según `TASKS_P2.md`
+- [ ] Sin `exit` dentro de módulos (solo `return`)
+- [ ] Mensajes usando `msg_ok`, `msg_err`, `msg_warn`
+- [ ] `pausar` al final de operaciones donde corresponde
+- [ ] **PC-1 adicional:** whiptail funciona en terminal interactiva
+- [ ] **PC-1 adicional:** listing de usuarios/grupos muestra correctamente
+- [ ] **P2-1 adicional:** `install_security.sh` corre sin errores en AlmaLinux 9.7
+- [ ] **P2-3 adicional:** cada herramienta verifica si está instalada antes de abrirse
+- [ ] PR tiene descripción completa en español
 
-**1. Verificar sintaxis (sin errores de compilación):**
-```bash
-bash -n src/<archivo-del-pr>.sh
-# Si no imprime nada → sin errores de sintaxis
-```
+---
 
-**2. Ejecutar el script completo y probar el módulo:**
-```bash
-sudo bash main.sh
-# Navegar al submenú del PR que estás revisando
-# Probar cada opción del menú al menos una vez
-```
+## Merge orden de merge sugerido
 
-**3. Casos de prueba mínimos por módulo:**
-
-| Módulo    | Qué probar                                                        |
-|-----------|-------------------------------------------------------------------|
-| utils     | Llamar `print_header`, `msg_ok`, `msg_err`, `confirmar_accion`    |
-| usuarios  | Alta con usuario nuevo, alta con usuario ya existente (debe fallar elegante), baja, consulta de usuario inexistente |
-| grupos    | Alta con grupo nuevo, baja, consulta, agregar miembro             |
-| procesos  | Usuario con procesos activos, usuario sin procesos, usuario inexistente |
-
-### Checklist de aprobación
-
-- [ ] `bash -n <archivo>` no reporta errores de sintaxis
-- [ ] El script completo corre sin errores al navegar por el módulo
-- [ ] Las funciones tienen los nombres correctos (sin cambiar los stubs)
-- [ ] Cada función verifica si el usuario/grupo existe antes de actuar
-- [ ] Se usan `msg_ok`, `msg_err`, `msg_warn` de `utils.sh` para todos los mensajes
-- [ ] Las acciones destructivas (baja, eliminar) piden confirmación con `confirmar_accion`
-- [ ] El PR tiene descripción completa en español
-- [ ] El código tiene comentarios mínimos que expliquen bloques no obvios
-
-Si algo del checklist falla, el revisor deja un comentario en español explicando exactamente qué falló y cómo reproducirlo, y **no aprueba** hasta que esté corregido.
+| Día | Actividad de merge |
+|-----|--------------------|
+| Mié 13 may | Revisar y mergear PC-1 (correcciones) → develop |
+| Jue 14 may | Revisar y mergear P2-1, P2-2, P2-3 → develop (en paralelo) |
+| Vie 15 may | Revisar y mergear P2-INT (integración) → develop |
+| Vie 15 may | Prueba de integración completa en develop |
+| Vie 15 may | Merge develop → main (Anthony) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,819 +1,666 @@
-# Tareas por PR — Admin de Redes Parte 1
+# Tareas por PR — Admin de Redes Parte 2
 
-Este documento describe exactamente qué debe implementar cada miembro del equipo.
 Lee únicamente la sección de tu PR asignado.
 
-> Antes de empezar: clona el repo, muévete a tu rama y corre `bash setup.sh` para
-> verificar que tu entorno de AlmaLinux 9 tiene todo lo necesario.
+> Antes de empezar: `git checkout <tu-rama>` y `bash setup.sh` para verificar el entorno.
 
 ---
 
-## PR #1 — utils/lib · `src/lib/utils.sh`
+## PC-1 — Correcciones Parte 1 · múltiples archivos
 
-**Rama:** `feat/utils-lib`  
-**Responsable:** Anthony  
-**Prioridad:** ALTA — merge el lunes. El resto del equipo depende de este archivo.
+**Rama:** `feat/part1-corrections`
+**Responsable:** Axel
+**Prioridad:** ALTA — merge el domingo 10.
 
 ### Contexto
 
-Este archivo es una librería de helpers. No tiene lógica de negocio propia — solo
-provee funciones reutilizables que los demás módulos llaman. Todos los módulos
-asumen que estas funciones existen con exactamente estos nombres.
+Este PR corrige las observaciones de la primera revisión del profesor.
+Toca 4 archivos existentes. No se crean archivos nuevos.
 
-> Si necesitas renombrar alguna función, avisa al equipo ANTES de hacer push.
-> Cambiar un nombre sin avisar rompe los otros cuatro módulos.
-
-### Funciones a implementar
+**Regla importante:** Las funciones existentes en `utils.sh` NO se eliminan ni renombran.
+Solo se agregan funciones nuevas. Esto evita romper los módulos de Parte 2 que se
+desarrollan en paralelo.
 
 ---
 
-#### `print_header <título>`
-
-Imprime un encabezado visual que separa visualmente cada sección del menú.
-
-**Comportamiento esperado:**
-- Recibe un string como argumento
-- Imprime una línea en blanco, luego el título resaltado, luego otra línea en blanco
-- Usa color cian o similar para destacarlo del resto del output
-
-**Ejemplo de salida:**
-```
-╔══════════════════════════════════════════╗
-  Gestión de Usuarios
-╚══════════════════════════════════════════╝
-```
-
-**Casos a manejar:**
-- Si no se pasa argumento, imprimir encabezado vacío (no romper)
+### 1. Nuevas funciones en `src/lib/utils.sh`
 
 ---
 
-#### `msg_ok <mensaje>`
+#### `seleccionar_usuario`
 
-Imprime un mensaje de éxito en color verde con prefijo `[OK]`.
+Muestra una lista de usuarios del sistema con UID ≥ 1000 usando whiptail.
+El usuario selecciona uno de la lista o cancela.
 
-**Comportamiento esperado:**
-- Salida a stdout
-- Color verde
-- Prefijo: `[OK]`
+**Retorna:** nombre del usuario seleccionado en stdout. Retorna 1 si cancela.
 
-**Ejemplo de salida:**
-```
-[OK] Usuario 'juan' creado correctamente.
-```
-
----
-
-#### `msg_err <mensaje>`
-
-Imprime un mensaje de error en color rojo con prefijo `[ERROR]`.
-
-**Comportamiento esperado:**
-- Salida a **stderr** (no stdout)
-- Color rojo
-- Prefijo: `[ERROR]`
-
-**Ejemplo de salida:**
-```
-[ERROR] El usuario 'juan' no existe.
-```
-
----
-
-#### `msg_warn <mensaje>`
-
-Imprime un aviso en color amarillo con prefijo `[AVISO]`.
-
-**Comportamiento esperado:**
-- Salida a stdout
-- Color amarillo
-- Prefijo: `[AVISO]`
-
-**Ejemplo de salida:**
-```
-[AVISO] Opción inválida. Intenta de nuevo.
-```
-
----
-
-#### `confirmar_accion <pregunta>`
-
-Solicita confirmación al usuario antes de ejecutar una acción irreversible.
-
-**Comportamiento esperado:**
-- Muestra la pregunta seguida de `[s/N]: `
-- Lee la respuesta del usuario
-- Retorna **0** si el usuario escribe `s` o `S`
-- Retorna **1** para cualquier otra entrada (incluyendo Enter vacío)
-- El default es NO (si el usuario solo presiona Enter, se cancela)
-
-**Ejemplo de uso en otro módulo:**
 ```bash
-if confirmar_accion "¿Deseas eliminar el usuario 'juan'?"; then
-    userdel juan
-    msg_ok "Usuario eliminado."
-else
-    msg_warn "Operación cancelada."
+# Ejemplo de uso en users.sh:
+usuario=$(seleccionar_usuario) || return
+```
+
+**Implementación sugerida:**
+```bash
+seleccionar_usuario() {
+    local usuarios=()
+    while IFS=: read -r nombre _ uid _; do
+        (( uid >= 1000 )) && usuarios+=("$nombre" "UID: $uid")
+    done < /etc/passwd
+
+    whiptail --title "Seleccionar Usuario" \
+             --menu "Elige un usuario:" 20 50 10 \
+             "${usuarios[@]}" \
+             3>&1 1>&2 2>&3
+}
+```
+
+---
+
+#### `seleccionar_grupo`
+
+Muestra una lista de grupos con GID ≥ 1000 usando whiptail.
+
+**Retorna:** nombre del grupo seleccionado. Retorna 1 si cancela.
+
+```bash
+# Ejemplo de uso en groups.sh:
+grupo=$(seleccionar_grupo) || return
+```
+
+**Implementación sugerida:**
+```bash
+seleccionar_grupo() {
+    local grupos=()
+    while IFS=: read -r nombre _ gid _; do
+        (( gid >= 1000 )) && grupos+=("$nombre" "GID: $gid")
+    done < /etc/group
+
+    whiptail --title "Seleccionar Grupo" \
+             --menu "Elige un grupo:" 20 50 10 \
+             "${grupos[@]}" \
+             3>&1 1>&2 2>&3
+}
+```
+
+---
+
+#### `input_campo <titulo> <prompt> [valor_inicial]`
+
+Reemplaza `read -rp` con un cuadro de input visual de whiptail.
+
+**Retorna:** texto ingresado en stdout. Retorna 1 si cancela.
+
+```bash
+nombre=$(input_campo "Alta de Usuario" "Nombre del nuevo usuario:") || return
+```
+
+---
+
+#### `confirmar_whiptail <titulo> <pregunta>`
+
+Reemplaza `confirmar_accion` con un cuadro de confirmación visual.
+
+**Retorna:** 0 si confirma (Sí), 1 si cancela (No).
+
+```bash
+if confirmar_whiptail "Baja de Usuario" "¿Eliminar al usuario '$usuario'?"; then
+    userdel "$usuario"
 fi
 ```
 
-**Casos a manejar:**
-- Respuesta vacía (solo Enter) → retorna 1 (no confirma)
-- Respuesta `S` mayúscula → retorna 0 (confirma)
-- Respuesta `si`, `yes`, `n`, `no` → retorna 1 (solo acepta `s` o `S`)
-
 ---
 
-#### `usuario_existe <nombre_usuario>`
+### 2. Actualizar `src/users.sh`
 
-Verifica si un usuario existe en el sistema.
+Aplicar en las funciones que requieren seleccionar un usuario existente:
+`usuario_baja`, `usuario_consulta`, `usuario_modificar`.
 
-**Comportamiento esperado:**
-- Retorna **0** si el usuario existe
-- Retorna **1** si no existe
-- No imprime nada (silencioso)
+**Flujo actualizado para cada una:**
+1. Llamar `seleccionar_usuario` para mostrar la lista con whiptail
+2. Si el usuario cancela → `return`
+3. Confirmar que el usuario aún existe con `usuario_existe` (validación de seguridad)
+4. Continuar con el flujo normal de la función
 
-**Implementación sugerida:** usar el comando `id`
+**Función `usuario_alta` NO cambia** — está creando uno nuevo, no seleccionando uno existente.
 
-**Ejemplo de uso en otro módulo:**
-```bash
-if usuario_existe "juan"; then
-    echo "El usuario existe"
-else
-    msg_err "El usuario 'juan' no existe en el sistema."
-fi
-```
+**Reemplazar también:**
+- `read -rp "..."` → `input_campo`
+- `confirmar_accion` → `confirmar_whiptail`
+- El menú principal de `menu_usuarios` puede usar `whiptail --menu`
 
 **Casos a manejar:**
-- Nombre vacío → retorna 1
-- Usuario del sistema (root, nobody) → debe retornar 0 correctamente
+| Caso | Comportamiento |
+|------|---------------|
+| No hay usuarios con UID ≥ 1000 | `msg_warn "No hay usuarios disponibles."` y return |
+| Usuario cancela la selección | return sin error |
+| Usuario seleccionado ya no existe | `msg_err` y return |
 
 ---
 
-#### `grupo_existe <nombre_grupo>`
+### 3. Actualizar `src/groups.sh`
 
-Verifica si un grupo existe en el sistema.
+Aplicar `seleccionar_grupo` en: `grupo_baja`, `grupo_consulta`, `grupo_modificar`.
 
-**Comportamiento esperado:**
-- Retorna **0** si el grupo existe
-- Retorna **1** si no existe
-- No imprime nada (silencioso)
+**Grupo alta NO cambia** — crea uno nuevo.
 
-**Implementación sugerida:** usar `getent group`
-
-**Casos a manejar:**
-- Nombre vacío → retorna 1
-- Grupos del sistema (root, wheel, sudo) → debe retornar 0 correctamente
+**Mismos criterios que users.sh:**
+- Reemplazar `read` + `confirmar_accion` con helpers whiptail
+- Manejar lista vacía (sin grupos con GID ≥ 1000)
+- Validar existencia tras selección
 
 ---
 
-#### `pausar`
+### 4. Agregar opción Root en `src/processes.sh`
 
-Detiene la ejecución hasta que el usuario presione Enter.
+Agregar opción 3 al `menu_procesos`:
 
-**Comportamiento esperado:**
-- Imprime una línea en blanco
-- Muestra el mensaje: `  Presiona Enter para continuar...`
-- Espera input del usuario (cualquier tecla + Enter)
-- Imprime una línea en blanco al salir
-
----
-
-### Cómo probar tu PR
-
-```bash
-# Carga el archivo directamente
-source src/lib/utils.sh
-
-# Prueba print_header
-print_header "Prueba de encabezado"
-
-# Prueba mensajes
-msg_ok "Todo bien"
-msg_err "Algo salió mal"
-msg_warn "Cuidado con esto"
-
-# Prueba confirmar_accion
-confirmar_accion "¿Confirmas la prueba?"
-echo "Retornó: $?"   # debe ser 0 si escribiste 's'
-
-# Prueba usuario_existe
-usuario_existe "root"
-echo "root existe: $?"     # debe ser 0
-
-usuario_existe "usuarioquenuncaexistira123"
-echo "inexistente: $?"     # debe ser 1
-
-# Prueba grupo_existe
-grupo_existe "root"
-echo "grupo root: $?"      # debe ser 0
-```
-
----
-
----
-
-## PR #3 — Módulo de usuarios · `src/users.sh`
-
-**Rama:** `feat/users-module`  
-**Responsable:** Diego  
-**Prioridad:** NORMAL — merge el martes.
-
-### Contexto
-
-Este módulo maneja toda la gestión de usuarios del sistema. Todos los mensajes
-de éxito/error deben usar las funciones de `utils.sh` (`msg_ok`, `msg_err`, etc.).
-No uses `echo` directo para mensajes al usuario.
-
-Las funciones de `utils.sh` ya están disponibles porque `main.sh` las carga antes
-de cargar este módulo.
-
-### Funciones a implementar
-
----
-
-#### `menu_usuarios`
-
-Muestra el submenú de usuarios en un bucle hasta que el usuario elija volver.
-
-**Comportamiento esperado:**
-- Limpiar pantalla (`clear`) al entrar
-- Mostrar `print_header "Gestión de Usuarios"`
-- Mostrar las 4 opciones numeradas + opción 0 para volver
-- Leer opción y llamar a la función correspondiente
-- Repetir hasta que el usuario elija 0
-
-**Opciones del menú:**
-```
-1) Alta de usuario
-2) Baja de usuario
-3) Consulta de usuario
-4) Modificaciones de usuario
-0) Volver al menú principal
-```
-
----
-
-#### `usuario_alta`
-
-Da de alta un nuevo usuario en el sistema.
-
-**Flujo completo:**
-1. Solicitar nombre de usuario al operador
-2. Verificar que el nombre no esté vacío
-3. Verificar que el usuario **NO** exista ya (usar `usuario_existe`)
-4. Si ya existe → `msg_err` y volver al menú (no continuar)
-5. Ejecutar `useradd -m -s /bin/bash <usuario>` (`-m` crea el home, `-s` asigna bash)
-6. Solicitar contraseña con `passwd <usuario>`
-7. Confirmar alta con `msg_ok`
-8. Llamar a `pausar`
-
-**Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Nombre vacío | `msg_err "El nombre no puede estar vacío."` y volver |
-| Usuario ya existe | `msg_err "El usuario '<nombre>' ya existe."` y volver |
-| `useradd` falla | `msg_err "No se pudo crear el usuario."` y volver |
-| Alta exitosa | `msg_ok "Usuario '<nombre>' creado correctamente."` |
-
----
-
-#### `usuario_baja`
-
-Elimina un usuario del sistema.
-
-**Flujo completo:**
-1. Solicitar nombre de usuario
-2. Verificar que el nombre no esté vacío
-3. Verificar que el usuario **SÍ** exista (usar `usuario_existe`)
-4. Si no existe → `msg_err` y volver
-5. Preguntar si se desea eliminar también el directorio home (`confirmar_accion`)
-6. Pedir confirmación final antes de eliminar (`confirmar_accion "¿Estás seguro?"`)
-7. Si confirma con home: `userdel -r <usuario>`; sin home: `userdel <usuario>`
-8. Confirmar con `msg_ok` o reportar error con `msg_err`
-
-**Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Nombre vacío | `msg_err` y volver |
-| Usuario no existe | `msg_err "El usuario '<nombre>' no existe."` y volver |
-| Usuario cancela confirmación | `msg_warn "Operación cancelada."` y volver |
-| Baja exitosa | `msg_ok "Usuario '<nombre>' eliminado."` |
-| Usuario tiene procesos activos | `userdel` fallará — capturar el error y mostrar `msg_err` |
-
----
-
-#### `usuario_consulta`
-
-Muestra información detallada de un usuario.
-
-**Flujo completo:**
-1. Solicitar nombre de usuario
-2. Verificar que exista
-3. Si no existe → `msg_err` y volver
-4. Mostrar la información del usuario
-
-**Información a mostrar:**
-```
-Usuario:     juan
-UID / GID:   1001 / 1001
-Grupos:      juan wheel audio
-Home:        /home/juan
-Shell:       /bin/bash
-Último login: [resultado de lastlog -u <usuario>]
---- Caducidad de contraseña ---
-[resultado de chage -l <usuario>]
-```
-
-**Comandos a usar:**
-- `id <usuario>` → UID, GID, grupos
-- `getent passwd <usuario>` → home y shell (campo 6 y 7, separados por `:`)
-- `chage -l <usuario>` → información de caducidad
-- `lastlog -u <usuario>` → último login (opcional, si falla no es crítico)
-
----
-
-#### `usuario_modificar`
-
-Submenú para modificar atributos de un usuario existente.
-
-**Flujo completo:**
-1. Solicitar nombre de usuario
-2. Verificar que exista
-3. Si no existe → `msg_err` y volver
-4. Mostrar submenú de modificaciones
-
-**Submenú de modificaciones:**
-```
-1) Cambiar fecha de caducidad de cuenta
-2) Cambiar directorio home
-3) Bloquear cuenta
-4) Desbloquear cuenta
-5) Cambiar shell
-0) Volver
-```
-
-**Comandos por opción:**
-
-| Opción | Comando | Notas |
-|--------|---------|-------|
-| Caducidad | `chage -E YYYY-MM-DD <usuario>` | Pedir fecha en formato YYYY-MM-DD |
-| Home | `usermod -d /nuevo/home <usuario>` | Advertir que no mueve los archivos existentes |
-| Bloquear | `usermod -L <usuario>` | Confirmar antes de ejecutar |
-| Desbloquear | `usermod -U <usuario>` | Confirmar antes de ejecutar |
-| Shell | `usermod -s /bin/bash <usuario>` | Pedir ruta del shell (ej. `/bin/bash`, `/bin/sh`) |
-
----
-
-### Cómo probar tu PR
-
-```bash
-# Ejecutar el script completo como root
-sudo bash main.sh
-
-# Navegar: Opción 1 (Usuarios)
-
-# Prueba 1 — Alta exitosa
-# → Opción 1, ingresar "testuser01", asignar contraseña
-# → Verificar: id testuser01
-
-# Prueba 2 — Alta duplicada
-# → Opción 1, ingresar "testuser01" de nuevo
-# → Debe mostrar [ERROR] usuario ya existe
-
-# Prueba 3 — Consulta
-# → Opción 3, ingresar "testuser01"
-# → Debe mostrar UID, GID, grupos, home, shell, caducidad
-
-# Prueba 4 — Modificar: bloquear cuenta
-# → Opción 4 → Opción 3 (bloquear) con "testuser01"
-# → Verificar: passwd -S testuser01  (debe mostrar "L" en segundo campo)
-
-# Prueba 5 — Baja con home
-# → Opción 2, ingresar "testuser01", confirmar eliminar home
-# → Verificar: id testuser01 debe fallar
-# → Verificar: ls /home/testuser01 debe fallar
-
-# Prueba 6 — Usuario inexistente
-# → Opción 3, ingresar "usuarioinexistente999"
-# → Debe mostrar [ERROR]
-
-# Verificar sintaxis antes del PR:
-bash -n src/users.sh
-```
-
----
-
----
-
-## PR #4 — Módulo de grupos · `src/groups.sh`
-
-**Rama:** `feat/groups-module`  
-**Responsable:** Imanol  
-**Prioridad:** NORMAL — merge el martes.
-
-### Contexto
-
-Este módulo maneja la gestión de grupos del sistema. Mismas reglas que el módulo
-de usuarios: todos los mensajes usan `utils.sh`, sin `echo` directo para mensajes.
-
-### Funciones a implementar
-
----
-
-#### `menu_grupos`
-
-Muestra el submenú de grupos en un bucle hasta que el usuario elija volver.
-
-**Opciones del menú:**
-```
-1) Alta de grupo
-2) Baja de grupo
-3) Consulta de grupo
-4) Modificaciones de grupo
-0) Volver al menú principal
-```
-
----
-
-#### `grupo_alta`
-
-Da de alta un nuevo grupo en el sistema.
-
-**Flujo completo:**
-1. Solicitar nombre del grupo
-2. Verificar que el nombre no esté vacío
-3. Verificar que el grupo **NO** exista (usar `grupo_existe`)
-4. Si ya existe → `msg_err` y volver
-5. Ejecutar `groupadd <grupo>`
-6. Preguntar si se quieren agregar miembros iniciales (`confirmar_accion`)
-7. Si sí: solicitar nombres separados por coma → `gpasswd -M user1,user2 <grupo>`
-8. Confirmar con `msg_ok`
-
-**Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Nombre vacío | `msg_err` y volver |
-| Grupo ya existe | `msg_err "El grupo '<nombre>' ya existe."` y volver |
-| Alta exitosa | `msg_ok "Grupo '<nombre>' creado correctamente."` |
-
----
-
-#### `grupo_baja`
-
-Elimina un grupo del sistema.
-
-**Flujo completo:**
-1. Solicitar nombre del grupo
-2. Verificar que el nombre no esté vacío
-3. Verificar que el grupo **SÍ** exista
-4. Si no existe → `msg_err` y volver
-5. Pedir confirmación con `confirmar_accion`
-6. Ejecutar `groupdel <grupo>`
-7. Confirmar con `msg_ok` o reportar error
-
-**Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Grupo no existe | `msg_err` y volver |
-| Usuario cancela | `msg_warn "Operación cancelada."` |
-| Grupo es primario de algún usuario | `groupdel` fallará — capturar error y mostrar `msg_err "No se puede eliminar: es grupo primario de algún usuario."` |
-| Baja exitosa | `msg_ok "Grupo '<nombre>' eliminado."` |
-
----
-
-#### `grupo_consulta`
-
-Muestra información de un grupo.
-
-**Flujo completo:**
-1. Solicitar nombre del grupo
-2. Verificar que exista
-3. Si no existe → `msg_err` y volver
-4. Mostrar información
-
-**Información a mostrar:**
-```
-Grupo:    devs
-GID:      1002
-Miembros: juan, pedro, maria
-```
-
-**Comandos a usar:**
-- `getent group <grupo>` → devuelve `nombre:x:GID:miembros`
-- Separar con `cut -d: -f3` (GID) y `cut -d: -f4` (miembros)
-- Si la lista de miembros está vacía → mostrar `(sin miembros)`
-
----
-
-#### `grupo_modificar`
-
-Submenú para modificar un grupo existente.
-
-**Flujo completo:**
-1. Solicitar nombre del grupo
-2. Verificar que exista
-3. Si no existe → `msg_err` y volver
-4. Mostrar submenú de modificaciones
-
-**Submenú:**
-```
-1) Renombrar grupo
-2) Agregar miembro
-3) Quitar miembro
-4) Reemplazar lista completa de miembros
-0) Volver
-```
-
-**Comandos por opción:**
-
-| Opción | Comando | Notas |
-|--------|---------|-------|
-| Renombrar | `groupmod -n <nuevo_nombre> <grupo>` | Verificar que el nuevo nombre no exista ya |
-| Agregar miembro | `gpasswd -a <usuario> <grupo>` | Verificar que el usuario exista con `usuario_existe` |
-| Quitar miembro | `gpasswd -d <usuario> <grupo>` | Verificar que el usuario exista |
-| Reemplazar lista | `gpasswd -M user1,user2,user3 <grupo>` | Solicitar lista separada por comas |
-
----
-
-### Cómo probar tu PR
-
-```bash
-sudo bash main.sh
-# Navegar: Opción 2 (Grupos)
-
-# Prueba 1 — Alta de grupo
-# → Opción 1, nombre "devteam", agregar miembro "root"
-# → Verificar: getent group devteam
-
-# Prueba 2 — Alta duplicada
-# → Opción 1, nombre "devteam" de nuevo
-# → Debe mostrar [ERROR]
-
-# Prueba 3 — Consulta
-# → Opción 3, nombre "devteam"
-# → Debe mostrar GID y miembros
-
-# Prueba 4 — Agregar miembro
-# → Opción 4 → Opción 2, agregar usuario "root" a "devteam"
-# → Verificar: id root (debe incluir devteam en grupos)
-
-# Prueba 5 — Quitar miembro
-# → Opción 4 → Opción 3, quitar "root" de "devteam"
-# → Verificar: getent group devteam
-
-# Prueba 6 — Baja de grupo
-# → Opción 2, nombre "devteam", confirmar
-# → Verificar: getent group devteam debe devolver vacío
-
-# Prueba 7 — Grupo inexistente
-# → Opción 3, nombre "grupoinexistente999"
-# → Debe mostrar [ERROR]
-
-bash -n src/groups.sh
-```
-
----
-
----
-
-## PR #5 — Módulo de procesos · `src/processes.sh`
-
-**Rama:** `feat/processes-module`  
-**Responsable:** Osvaldo  
-**Prioridad:** NORMAL — merge el martes. Es el módulo más acotado del proyecto.
-
-### Contexto
-
-Este módulo muestra los procesos activos de un usuario consultado. No modifica
-nada en el sistema — es solo lectura. Mismas reglas de mensajes con `utils.sh`.
-
-### Funciones a implementar
-
----
-
-#### `menu_procesos`
-
-Muestra el submenú de procesos.
-
-**Opciones del menú:**
+**Menú actualizado:**
 ```
 1) Ver procesos del usuario (snapshot)
 2) Monitor en tiempo real (top)
+3) Ver procesos de root
+0) Volver al menú principal
+```
+
+**Nueva función `procesos_root`:**
+- Ejecuta directamente `ps aux --user root`
+- Cuenta procesos y muestra `msg_ok` con el conteo
+- Llama a `pausar` al final
+- No solicita nombre de usuario (va directo a root)
+
+---
+
+### Cómo probar PC-1
+
+```bash
+bash -n src/lib/utils.sh
+bash -n src/users.sh
+bash -n src/groups.sh
+bash -n src/processes.sh
+
+sudo bash main.sh
+# → Opción 1: verificar que baja/consulta/modificar muestran lista whiptail
+# → Opción 2: verificar que baja/consulta/modificar muestran lista whiptail
+# → Opción 3: verificar que opción 3 muestra procesos de root directamente
+# → Navegar todo el menú y verificar que el diseño se ve profesional
+```
+
+---
+
+---
+
+## P2-1 — Automatización + Script de instalación
+
+**Rama:** `feat/automation-module`
+**Responsable:** Osvaldo
+**Archivos:** `src/automation.sh`, `scripts/install_security.sh`
+
+### Contexto
+
+Este PR tiene dos entregables independientes. El script de instalación es
+un utilitario que todo el equipo ejecuta en sus máquinas para tener las
+herramientas de seguridad disponibles. El módulo de automatización es la
+opción 4 del menú principal.
+
+---
+
+### Entregable 1: `src/automation.sh`
+
+#### `menu_automatizacion`
+
+```
+1) Programar tarea con Cron (recurrente)
+2) Programar tarea con At (puntual)
+3) Ver tareas programadas en Cron
+4) Ver cola de At
 0) Volver al menú principal
 ```
 
 ---
 
-#### `procesos_snapshot`
+#### `automatizar_cron`
 
-Muestra una foto instantánea de los procesos activos de un usuario.
+Programa una tarea recurrente en el crontab del usuario root.
 
 **Flujo completo:**
-1. Solicitar nombre de usuario
-2. Verificar que el nombre no esté vacío
-3. Verificar que el usuario **SÍ** exista (usar `usuario_existe`)
-4. Si no existe → `msg_err` y volver
-5. Ejecutar `ps aux --user <usuario>` y capturar el resultado
-6. Contar cuántos procesos se encontraron (líneas del resultado menos el header)
-7. Si no hay procesos → `msg_warn "El usuario '<nombre>' no tiene procesos activos."`
-8. Si hay procesos → mostrar el resultado y al final: `msg_ok "X proceso(s) encontrado(s)."`
-9. Llamar a `pausar`
+1. Solicitar comando a ejecutar (ej: `/usr/bin/df -h >> /var/log/disco.log`)
+2. Solicitar programación — ofrecer opciones simples:
+   ```
+   1) Cada minuto          → * * * * *
+   2) Cada hora            → 0 * * * *
+   3) Diariamente (00:00)  → 0 0 * * *
+   4) Semanalmente (lunes) → 0 0 * * 1
+   5) Mensualmente (día 1) → 0 0 1 * *
+   6) Personalizado        → pedir expresión cron manual
+   ```
+3. Mostrar la línea cron completa antes de confirmar
+4. Agregar al crontab: `(crontab -l 2>/dev/null; echo "<cron> <comando>") | crontab -`
+5. Confirmar con `msg_ok`
 
 **Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Nombre vacío | `msg_err` y volver |
-| Usuario no existe | `msg_err "El usuario '<nombre>' no existe."` y volver |
-| Sin procesos activos | `msg_warn "No hay procesos activos para '<nombre>'."` |
-| Con procesos | Mostrar salida de `ps aux` + conteo al final |
+| Caso | Comportamiento |
+|------|---------------|
+| Comando vacío | `msg_err` y return |
+| `crontab` no disponible | `msg_err "Instalar cronie: dnf install cronie"` |
+| Expresión personalizada vacía | `msg_err` y return |
 
-**Sugerencia de implementación:**
+---
+
+#### `automatizar_at`
+
+Programa una tarea puntual para ejecutarse una sola vez.
+
+**Flujo completo:**
+1. Verificar que `at` esté instalado (`command -v at`)
+2. Solicitar comando a ejecutar
+3. Solicitar fecha y hora en formato `HH:MM MM/DD/YYYY`
+   (ej: `23:30 05/15/2026`)
+4. Mostrar resumen antes de confirmar
+5. Ejecutar: `echo "<comando>" | at <fecha>`
+6. Confirmar con `msg_ok` y mostrar el job ID asignado
+
+**Casos a manejar:**
+| Caso | Comportamiento |
+|------|---------------|
+| `at` no instalado | `msg_err "Instalar at: dnf install at"` |
+| Formato de fecha inválido | `at` lo detecta — capturar stderr y mostrar `msg_err` |
+| Servicio `atd` no corriendo | `msg_warn "Iniciar servicio: systemctl start atd"` |
+
+---
+
+#### `listar_cron`
+
+Muestra el crontab actual de root.
+
 ```bash
-# Capturar procesos sin el header
-PROCESOS=$(ps aux --user "$usuario" 2>/dev/null | tail -n +2)
-
-# Contar líneas
-COUNT=$(echo "$PROCESOS" | grep -c .)
-
-if [[ $COUNT -eq 0 ]]; then
-    msg_warn "El usuario '$usuario' no tiene procesos activos."
-else
-    ps aux --user "$usuario"
-    echo ""
-    msg_ok "$COUNT proceso(s) encontrado(s) para '$usuario'."
-fi
+crontab -l 2>/dev/null || msg_warn "No hay tareas programadas en crontab."
 ```
 
 ---
 
-#### `procesos_monitor`
+#### `listar_at`
 
-Abre el monitor `top` filtrado por un usuario específico para visualización en tiempo real.
+Muestra la cola de trabajos de at.
 
-**Flujo completo:**
-1. Solicitar nombre de usuario
-2. Verificar que el nombre no esté vacío
-3. Verificar que el usuario **SÍ** exista
-4. Si no existe → `msg_err` y volver
-5. Avisar al usuario que presione `q` para salir de `top`
-6. Ejecutar `top -u <usuario>`
-7. Al regresar (el usuario presionó `q`), llamar a `pausar`
-
-**Casos a manejar:**
-| Caso | Comportamiento esperado |
-|------|------------------------|
-| Nombre vacío | `msg_err` y volver |
-| Usuario no existe | `msg_err` y volver |
-| Antes de abrir top | `msg_warn "Presiona 'q' para salir del monitor."` |
+```bash
+atq 2>/dev/null || msg_warn "No hay trabajos pendientes en at."
+```
 
 ---
 
-### Cómo probar tu PR
+### Entregable 2: `scripts/install_security.sh`
+
+Script que instala y configura las herramientas de seguridad en AlmaLinux 9.7.
+Todo el equipo lo ejecuta una vez antes de la demo.
+
+**Flujo del script:**
 
 ```bash
+#!/usr/bin/env bash
+# scripts/install_security.sh
+# Uso: sudo bash scripts/install_security.sh
+```
+
+**Pasos a implementar:**
+
+1. Verificar AlmaLinux 9
+2. Verificar que se ejecuta como root
+3. Actualizar el sistema: `dnf update -y`
+4. Habilitar repositorio CRB: `dnf config-manager --set-enabled crb`
+5. Instalar EPEL: `dnf install -y epel-release`
+6. Poner SELinux en permissive:
+   ```bash
+   setenforce 0
+   sed -i 's/SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
+   ```
+7. Instalar herramientas:
+   ```bash
+   dnf install -y nagios nagios-common nagios-plugins-all nrpe nagios-plugins-nrpe
+   dnf install -y wireshark-qt nmap iftop at cronie
+   ```
+8. Configurar nagiosadmin (pedir contraseña interactivamente):
+   ```bash
+   htpasswd -c /etc/nagios/passwd nagiosadmin
+   ```
+9. Habilitar y arrancar servicios:
+   ```bash
+   systemctl enable --now httpd nagios
+   ```
+10. Abrir firewall para http:
+    ```bash
+    firewall-cmd --permanent --add-service=http
+    firewall-cmd --reload
+    ```
+11. Verificar que Nagios responde: `curl -s http://localhost/nagios | grep -q Nagios`
+12. Mostrar resumen final con URLs y credenciales
+
+**Casos a manejar:**
+- Si un paso falla, mostrar el error y continuar (no usar `set -e`)
+- Al final indicar qué pasos tuvieron éxito y cuáles fallaron
+
+---
+
+### Cómo probar P2-1
+
+```bash
+bash -n src/automation.sh
+
+# Probar install script:
+sudo bash scripts/install_security.sh
+# → Debe completarse sin errores fatales
+# → Nagios debe estar corriendo: systemctl status nagios
+
+# Probar módulo de automatización:
 sudo bash main.sh
-# Navegar: Opción 3 (Procesos)
-
-# Prueba 1 — Snapshot de root (siempre tiene procesos)
-# → Opción 1, ingresar "root"
-# → Debe mostrar lista de procesos y conteo mayor a 0
-
-# Prueba 2 — Usuario sin procesos
-# → Crear un usuario de prueba: sudo useradd testproc
-# → Opción 1, ingresar "testproc"
-# → Debe mostrar [AVISO] sin procesos activos
-
-# Prueba 3 — Usuario inexistente
-# → Opción 1, ingresar "usuarioinexistente999"
-# → Debe mostrar [ERROR]
-
-# Prueba 4 — Monitor en tiempo real
-# → Opción 2, ingresar "root"
-# → Debe abrir top filtrado por root
-# → Presionar q para salir
-# → Debe regresar al menú correctamente
-
-# Prueba 5 — Nombre vacío
-# → Opción 1, presionar Enter sin escribir nada
-# → Debe mostrar [ERROR]
-
-bash -n src/processes.sh
+# → Opción 4 (Automatización)
+# → Opción 1: programar "echo hola >> /tmp/test.log" cada minuto
+# → Verificar: crontab -l | grep "echo hola"
+# → Opción 3: debe mostrar la tarea recién creada
+# → Opción 2: programar tarea con at para 1 minuto adelante
+# → Verificar: atq
 ```
 
 ---
 
 ---
 
-## PR #2 — Core / Entrypoint · `main.sh`
+## P2-2 — Respaldo de información
 
-**Rama:** `feat/core-entrypoint`  
-**Responsable:** Axel  
-**Prioridad:** ALTA — pero merge el **último**, después de que todos los demás estén en develop.
+**Rama:** `feat/backup-module`
+**Responsable:** Imanol
+**Archivo:** `src/backup.sh`
 
 ### Contexto
 
-`main.sh` es el punto de entrada del script. Se encarga de tres cosas:
-verificar que quien lo ejecuta es root, cargar todos los módulos, y mostrar
-el menú principal. No implementa lógica de usuarios, grupos ni procesos —
-eso vive en cada módulo. Su trabajo es ensamblar todo.
-
-### Qué implementar
+Módulo para comprimir carpetas del sistema en dos formatos.
+No modifica nada existente — solo crea el archivo nuevo.
 
 ---
 
-#### Verificación de root
+#### `menu_respaldo`
 
-Al inicio del script, antes de cualquier menú:
-
-```bash
-if [[ $EUID -ne 0 ]]; then
-    echo ""
-    echo "Acceso denegado: este script debe ejecutarse como root."
-    echo "Usa: sudo bash main.sh"
-    echo ""
-    exit 1
-fi
 ```
+1) Respaldo con Gzip  (.tar.gz)
+2) Respaldo con Bzip2 (.tar.bz2)
+0) Volver al menú principal
+```
+
+---
+
+#### `respaldar_gzip` y `respaldar_bzip2`
+
+Ambas funciones siguen el mismo flujo. La única diferencia es el flag de `tar`
+(`-czf` para gzip, `-cjf` para bzip2) y la extensión del archivo resultante.
+
+**Flujo completo:**
+1. Solicitar carpeta origen (ej: `/home/anthony`)
+2. Verificar que la carpeta origen existe (`[[ -d "$origen" ]]`)
+3. Si no existe → `msg_err "La carpeta '$origen' no existe."` y return
+4. Solicitar ruta de destino (ej: `/backups`)
+5. Verificar que la ruta de destino existe y tiene permisos de escritura
+6. Si no existe → preguntar con `confirmar_accion` si se desea crearla
+7. Generar nombre automático del archivo:
+   ```bash
+   nombre="backup_$(basename "$origen")_$(date +%Y%m%d_%H%M%S).tar.gz"
+   ```
+8. Ejecutar tar con barra de progreso:
+   ```bash
+   tar -czf "$destino/$nombre" "$origen" 2>/dev/null
+   ```
+9. Verificar que el archivo se creó correctamente (`[[ -f "$destino/$nombre" ]]`)
+10. Mostrar tamaño del respaldo: `du -sh "$destino/$nombre"`
+11. Confirmar con `msg_ok "Respaldo creado: $destino/$nombre (tamaño: X)"`
+12. Llamar a `pausar`
 
 **Casos a manejar:**
-- Si el usuario NO es root → imprimir mensaje y salir con código 1
-- Si el usuario SÍ es root → continuar al menú principal
+| Caso | Comportamiento |
+|------|---------------|
+| Carpeta origen no existe | `msg_err` y return |
+| Ruta destino no existe | ofrecer crearla con `mkdir -p` |
+| Sin espacio suficiente | `tar` fallará — capturar `$?` y mostrar `msg_err` |
+| Sin permisos en destino | `msg_err "Sin permisos de escritura en '$destino'"` |
+| Carpeta origen vacía | continuar normalmente (tar crea archivo vacío) |
 
 ---
 
-#### Carga de módulos
-
-Después de la verificación de root, cargar los cuatro archivos en orden:
+### Cómo probar P2-2
 
 ```bash
-source "$SCRIPT_DIR/src/lib/utils.sh"
-source "$SCRIPT_DIR/src/users.sh"
-source "$SCRIPT_DIR/src/groups.sh"
-source "$SCRIPT_DIR/src/processes.sh"
-```
+bash -n src/backup.sh
 
-Usar `SCRIPT_DIR` para que el script funcione desde cualquier directorio:
-
-```bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-```
-
----
-
-#### Menú principal
-
-Bucle que muestra las tres opciones principales más la salida:
-
-```
-1) Usuarios
-2) Grupos
-3) Procesos de usuario
-0) Salir
-```
-
-**Comportamiento:**
-- Limpiar pantalla (`clear`) en cada iteración
-- Mostrar `print_header "Administración de Redes — Menú Principal"`
-- Leer opción y llamar al menú del módulo correspondiente
-- Opción 0: imprimir despedida y salir con código 0
-- Opción inválida: `msg_warn` + `pausar`
-
----
-
-### Cómo probar tu PR
-
-```bash
-# Prueba 1 — Sin root
-bash main.sh
-# Debe mostrar "Acceso denegado" y salir
-
-# Prueba 2 — Con root, navegación completa
 sudo bash main.sh
-# → Entrar a cada submenú (1, 2, 3) y volver con 0
-# → Verificar que los módulos cargan sin errores
+# → Opción 5 (Respaldo)
 
-# Prueba 3 — Opción inválida en menú principal
+# Prueba 1 — gzip exitoso
+# → Opción 1, origen: /etc, destino: /tmp
+# → Verificar: ls -lh /tmp/backup_etc_*.tar.gz
+
+# Prueba 2 — bzip2 exitoso
+# → Opción 2, origen: /var/log, destino: /tmp
+# → Verificar: ls -lh /tmp/backup_log_*.tar.bz2
+# → Verificar que se puede extraer: tar -tjf /tmp/backup_log_*.tar.bz2 | head
+
+# Prueba 3 — carpeta inexistente
+# → Opción 1, origen: /carpetafalsa999
+# → Debe mostrar [ERROR]
+
+# Prueba 4 — destino inexistente
+# → Opción 1, origen: /etc, destino: /ruta/que/no/existe
+# → Debe preguntar si crear la carpeta
+```
+
+---
+
+---
+
+## P2-3 — Seguridad / Monitoreo
+
+**Rama:** `feat/security-module`
+**Responsable:** Diego
+**Archivo:** `src/security.sh`
+
+### Contexto
+
+Módulo que abre herramientas de monitoreo. Asume que
+`scripts/install_security.sh` ya se ejecutó en la máquina.
+Si una herramienta no está instalada, muestra `msg_err` con instrucción de
+correr el script.
+
+**Coordinación:** ejecuta `sudo bash scripts/install_security.sh` antes de
+comenzar a probar este módulo.
+
+---
+
+#### `menu_seguridad`
+
+```
+1) Nagios     (dashboard web)
+2) Wireshark  (captura de tráfico)
+3) Nmap / iftop (monitoreo de red)
+0) Volver al menú principal
+```
+
+---
+
+#### `abrir_nagios`
+
+**Flujo completo:**
+1. Verificar que `nagios` está instalado: `command -v nagios`
+2. Si no está → `msg_err "Nagios no instalado. Ejecuta: sudo bash scripts/install_security.sh"` y return
+3. Verificar que el servicio `nagios` está corriendo: `systemctl is-active nagios`
+4. Si no está corriendo → intentar iniciarlo: `systemctl start nagios httpd`
+5. Verificar que `httpd` está corriendo
+6. Mostrar `msg_ok "Abriendo Nagios en el navegador..."`
+7. Mostrar URL: `http://localhost/nagios` y credenciales: usuario `nagiosadmin`
+8. Abrir en navegador: `xdg-open http://localhost/nagios &`
+9. Llamar a `pausar`
+
+**Casos a manejar:**
+| Caso | Comportamiento |
+|------|---------------|
+| Nagios no instalado | `msg_err` con instrucción |
+| Servicio caído | intentar `systemctl start` y reportar resultado |
+| `xdg-open` no disponible | mostrar URL para abrir manualmente |
+
+---
+
+#### `abrir_wireshark`
+
+**Flujo completo:**
+1. Verificar que `wireshark` está instalado: `command -v wireshark`
+2. Si no → `msg_err` con instrucción y return
+3. `msg_warn "Wireshark se abrirá en una ventana separada."`
+4. Lanzar en segundo plano: `wireshark &`
+5. `msg_ok "Wireshark iniciado. Cierra la ventana para volver al script."`
+6. Llamar a `pausar`
+
+---
+
+#### `menu_monitor_red`
+
+Submenú para elegir entre Nmap y iftop:
+
+```
+1) Nmap  — escaneo de puertos y hosts
+2) iftop — monitor de tráfico en tiempo real
+0) Volver
+```
+
+**`ejecutar_nmap`:**
+1. Verificar instalación
+2. Solicitar objetivo: IP, rango (ej: `192.168.1.0/24`) o `localhost`
+3. Ofrecer tipo de escaneo:
+   ```
+   1) Escaneo básico de puertos    → nmap <objetivo>
+   2) Detección de versiones       → nmap -sV <objetivo>
+   3) Escaneo de red local         → nmap -sn <objetivo>
+   ```
+4. Ejecutar y mostrar resultado en terminal
+5. Llamar a `pausar`
+
+**`ejecutar_iftop`:**
+1. Verificar instalación
+2. `msg_warn "iftop se ejecutará en tiempo real. Presiona 'q' para salir."`
+3. Ejecutar: `iftop`
+4. Llamar a `pausar` al regresar
+
+---
+
+### Cómo probar P2-3
+
+```bash
+# Prerequisito: ejecutar primero
+sudo bash scripts/install_security.sh
+
+bash -n src/security.sh
+
 sudo bash main.sh
-# → Escribir "9" o letras
-# → Debe mostrar [AVISO] y no romper el bucle
+# → Opción 6 (Seguridad)
 
-# Prueba 4 — Salida limpia
-# → Opción 0 desde el menú principal
-# → Debe imprimir despedida y salir sin errores
+# Prueba 1 — Nagios
+# → Opción 1: debe abrir http://localhost/nagios en el navegador
+# → Verificar: systemctl status nagios debe estar activo
 
+# Prueba 2 — Wireshark
+# → Opción 2: debe abrir la interfaz gráfica de Wireshark
+# → Verificar que el proceso existe: pgrep wireshark
+
+# Prueba 3 — Nmap
+# → Opción 3 → Opción 1, objetivo: localhost
+# → Debe mostrar puertos abiertos
+
+# Prueba 4 — iftop
+# → Opción 3 → Opción 2
+# → Debe abrir monitor en tiempo real, salir con q
+
+# Prueba 5 — herramienta no instalada (simulación)
+# Renombrar temporalmente: mv /usr/bin/nmap /usr/bin/nmap.bak
+# → Debe mostrar [ERROR] con instrucción
+# Restaurar: mv /usr/bin/nmap.bak /usr/bin/nmap
+```
+
+---
+
+---
+
+## P2-INT — Integración Parte 2
+
+**Rama:** `feat/part2-integration`
+**Responsable:** Anthony
+**Archivo:** `main.sh`, `deps.txt`
+**Prioridad:** ALTA — merge el último.
+
+### Contexto
+
+Integra los 3 módulos nuevos en `main.sh` y aplica whiptail al menú principal.
+Este PR se codifica cuando P2-1, P2-2 y P2-3 ya están en develop.
+Durante los días de coding (antes de que los módulos estén listos),
+Anthony se enfoca en revisar los otros PRs.
+
+---
+
+### Cambios en `main.sh`
+
+**1. Agregar sources de nuevos módulos:**
+```bash
+source "$SCRIPT_DIR/src/automation.sh"
+source "$SCRIPT_DIR/src/backup.sh"
+source "$SCRIPT_DIR/src/security.sh"
+```
+
+**2. Actualizar menú principal con whiptail:**
+
+```bash
+main() {
+    while true; do
+        opcion=$(whiptail --title "Administración de Redes" \
+                          --menu "Selecciona una opción:" 20 60 9 \
+                          "1" "Usuarios" \
+                          "2" "Grupos" \
+                          "3" "Procesos" \
+                          "4" "Automatización de tareas" \
+                          "5" "Respaldo de información" \
+                          "6" "Seguridad / Monitoreo" \
+                          "0" "Salir" \
+                          3>&1 1>&2 2>&3) || exit 0
+
+        case $opcion in
+            1) menu_usuarios ;;
+            2) menu_grupos   ;;
+            3) menu_procesos ;;
+            4) menu_automatizacion ;;
+            5) menu_respaldo ;;
+            6) menu_seguridad ;;
+            0) exit 0 ;;
+        esac
+    done
+}
+```
+
+**3. Actualizar `deps.txt`** con los nuevos paquetes documentados en `PLANNING_P2.md`.
+
+---
+
+### Cómo probar P2-INT
+
+```bash
 bash -n main.sh
+
+sudo bash main.sh
+# → Verificar que el menú principal muestra las 6 opciones con whiptail
+# → Navegar a cada opción y confirmar que los módulos cargan
+# → Opción 0: salir limpiamente
+# → Prueba sin root: bash main.sh → debe mostrar "Acceso denegado"
 ```
 
 ---
 
 ## Notas generales para todos los PRs
 
-- Cada función debe terminar con `pausar` cuando corresponda (después de mostrar
-  información o confirmar una acción), para que el usuario pueda leer el resultado
-  antes de que la pantalla se limpie.
-- Nunca usar `exit` dentro de un módulo — solo `return` para volver al menú.
-  El único `exit` permitido está en `main.sh`.
-- Si un comando del sistema falla (useradd, groupdel, etc.), verificar el código
-  de retorno con `$?` y reportar el error con `msg_err`.
-- Probar siempre con `bash -n <archivo>` antes de abrir el PR.
+- Nunca usar `exit` dentro de un módulo — solo `return`
+- El único `exit` permitido está en `main.sh`
+- Si un comando del sistema falla, capturar `$?` y reportar con `msg_err`
+- Probar siempre `bash -n <archivo>` antes de abrir el PR
+- Verificar también con `source` que no hay errores de runtime
+- La descripción del PR en GitHub debe estar en español con secciones:
+  qué hace, funciones implementadas, cómo probarlo, notas adicionales


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la documentación completa de planificación para la Parte 2 del
proyecto y las correcciones de la primera revisión. Incluye los archivos
de planeación, responsabilidades, tareas detalladas e issues listos para
asignar en GitHub Projects.

## Archivos agregados
- **PLANNING.md**: estado del proyecto, nuevas funcionalidades,
  decisiones técnicas (whiptail, EPEL para Nagios) y estructura final del repo
- **RESPONSIBILITIES.md**: asignaciones por PR, orden de merge,
  cronograma del 10 al 15 de mayo y criterios de revisión
- **TASKS.md**: detalle función por función de qué implementar en cada
  PR con flujos completos, casos de error y cómo probar

## Cómo probarlo
Solo es documentación — verificar que los archivos renderizan
correctamente en GitHub y que los enlaces entre documentos funcionan.

## Notas adicionales
- La decisión de usar whiptail (preinstalado en AlmaLinux 9) resuelve
  simultáneamente la corrección de diseño y el listado de usuarios/grupos
- Nagios se instala vía EPEL para evitar los problemas de compatibilidad
  con la instalación desde código fuente en AlmaLinux 9.7
- P2-INT (Anthony) mergea de último ya que integra todos los módulos
  en main.sh — el resto de PRs son completamente independientes entre sí