### PR TITLE
feat(backup): implement gzip and bzip2 backup module

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -16,6 +16,7 @@ source "$SCRIPT_DIR/src/users.sh"
 source "$SCRIPT_DIR/src/groups.sh"
 source "$SCRIPT_DIR/src/processes.sh"
 source "$SCRIPT_DIR/src/automation.sh"
+source "$SCRIPT_DIR/src/backup.sh"
 source "$SCRIPT_DIR/src/security.sh"
 
 # ─── Verificación de root ─────────────────────────────────────────────────────
@@ -33,11 +34,12 @@ main() {
 
     while true; do
         opcion=$(whiptail --title "Administración de Redes — Menú Principal" \
-            --menu "Selecciona un módulo a gestionar:" 18 60 6 \
+            --menu "Selecciona un módulo a gestionar:" 20 60 7 \
             "1" "Usuarios" \
             "2" "Grupos" \
             "3" "Procesos de usuario" \
             "4" "Automatización de tareas" \
+            "5" "Respaldo de información" \
             "6" "Seguridad / Monitoreo" \
             "0" "Salir" \
             3>&1 1>&2 2>&3)
@@ -54,6 +56,7 @@ main() {
             2) menu_grupos         ;;
             3) menu_procesos       ;;
             4) menu_automatizacion ;;
+            5) menu_respaldo       ;;
             6) menu_seguridad      ;;
             *)
                 msg_warn "Opción inválida. Intenta de nuevo."

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -159,6 +159,12 @@ respaldar_bzip2() {
     # Solicitar carpeta origen
     read -rp "Carpeta origen: " origen
 
+    if [[ -z "$origen" ]]; then
+        msg_err "La ruta de origen no puede estar vacía."
+        pausar
+        return
+    fi
+
     # Validar existencia de carpeta origen
     if [[ ! -d "$origen" ]]; then
         msg_err "La carpeta '$origen' no existe."
@@ -168,6 +174,12 @@ respaldar_bzip2() {
 
     # Solicitar carpeta destino
     read -rp "Ruta destino: " destino
+
+    if [[ -z "$destino" ]]; then
+        msg_err "La ruta de destino no puede estar vacía."
+        pausar
+        return
+    fi
 
     # Verificar si la carpeta destino existe
     if [[ ! -d "$destino" ]]; then

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# src/backup.sh — Módulo de respaldo de información
+# Plataforma: AlmaLinux 9 | Bash 5.0+
+#
+# Autor del módulo: Imanol (PR P2-2 · feat/backup-module)
+#
+# Comandos del sistema que utilizarás:
+#   tar     → crear respaldos .tar.gz y .tar.bz2
+#   du      → mostrar tamaño del archivo generado
+#   mkdir   → crear directorios destino
+#   basename → obtener nombre de carpeta origen
+#   date    → generar timestamp automático
+#
+# Nota:
+# utils.sh ya fue cargado por main.sh.
+# Puedes usar directamente:
+#   print_header, msg_ok, msg_err, msg_warn,
+#   confirmar_accion y pausar
+#
+
+# ──────────────────────────────────────────────────────────────────────────────
+# menu_respaldo
+# Muestra el submenú de respaldos.
+# ──────────────────────────────────────────────────────────────────────────────
+menu_respaldo() {
+    local opcion
+
+    while true; do
+        clear
+        print_header "Respaldo de Información"
+
+        echo "  1) Respaldo con Gzip (.tar.gz)"
+        echo "  2) Respaldo con Bzip2 (.tar.bz2)"
+        echo ""
+        echo "  0) Volver al menú principal"
+        echo ""
+
+        read -rp "  Selecciona una opción: " opcion
+        echo ""
+
+        case $opcion in
+            1) respaldar_gzip ;;
+            2) respaldar_bzip2 ;;
+            0) return ;;
+            *) msg_warn "Opción inválida."; pausar ;;
+        esac
+    done
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# respaldar_gzip
+# Crea un respaldo comprimido en formato .tar.gz
+# ──────────────────────────────────────────────────────────────────────────────
+respaldar_gzip() {
+    print_header "Respaldo con Gzip"
+
+    local origen
+    local destino
+
+    # Solicitar carpeta origen
+    read -rp "Carpeta origen: " origen
+
+    # Validar existencia de carpeta origen
+    if [[ ! -d "$origen" ]]; then
+        msg_err "La carpeta '$origen' no existe."
+        pausar
+        return
+    fi
+
+    # Solicitar carpeta destino
+    read -rp "Ruta destino: " destino
+
+
+    # Verificar si la carpeta destino existe
+    if [[ ! -d "$destino" ]]; then
+        msg_warn "La carpeta '$destino' no existe."
+
+        if confirmar_accion "¿Deseas crearla?"; then
+            mkdir -p "$destino" 2>/dev/null
+
+            if [[ $? -ne 0 ]]; then
+                msg_err "No se pudo crear la carpeta '$destino'."
+                pausar
+                return
+            fi
+
+            msg_ok "Carpeta creada correctamente."
+        else
+            msg_warn "Operación cancelada."
+            pausar
+            return
+        fi
+    fi
+
+    # Verificar permisos de escritura
+    if [[ ! -w "$destino" ]]; then
+        msg_err "Sin permisos de escritura en '$destino'."
+        pausar
+        return
+    fi
+
+    local nombre
+    local tamano
+
+    # Generar nombre automático del respaldo
+    nombre="backup_$(basename "$origen")_$(date +%Y%m%d_%H%M%S).tar.gz"
+
+    # Crear respaldo comprimido
+    tar -czf "$destino/$nombre" -C "$(dirname "$origen")" "$(basename "$origen")"
+
+    # Verificar si tar falló
+    if [[ $? -ne 0 ]]; then
+        msg_err "No se pudo crear el respaldo."
+        pausar
+        return
+    fi
+
+    # Verificar que el archivo exista
+    if [[ ! -f "$destino/$nombre" ]]; then
+        msg_err "El archivo de respaldo no fue creado."
+        pausar
+        return
+    fi
+
+    # Obtener tamaño del archivo
+    tamano=$(du -sh "$destino/$nombre" | awk '{print $1}')
+
+    msg_ok "Respaldo creado: $destino/$nombre (tamaño: $tamano)"
+
+    pausar
+
+
+
+
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# respaldar_bzip2
+# Crea un respaldo comprimido en formato .tar.bz2
+# ──────────────────────────────────────────────────────────────────────────────
+respaldar_bzip2() {
+    print_header "Respaldo con Bzip2"
+
+    local origen
+    local destino
+
+    # Solicitar carpeta origen
+    read -rp "Carpeta origen: " origen
+
+    # Validar existencia de carpeta origen
+    if [[ ! -d "$origen" ]]; then
+        msg_err "La carpeta '$origen' no existe."
+        pausar
+        return
+    fi
+
+    # Solicitar carpeta destino
+    read -rp "Ruta destino: " destino
+
+    # Verificar si la carpeta destino existe
+    if [[ ! -d "$destino" ]]; then
+        msg_warn "La carpeta '$destino' no existe."
+
+        if confirmar_accion "¿Deseas crearla?"; then
+            mkdir -p "$destino" 2>/dev/null
+
+            if [[ $? -ne 0 ]]; then
+                msg_err "No se pudo crear la carpeta '$destino'."
+                pausar
+                return
+            fi
+
+            msg_ok "Carpeta creada correctamente."
+        else
+            msg_warn "Operación cancelada."
+            pausar
+            return
+        fi
+    fi
+
+    # Verificar permisos de escritura
+    if [[ ! -w "$destino" ]]; then
+        msg_err "Sin permisos de escritura en '$destino'."
+        pausar
+        return
+    fi
+
+    local nombre
+    local tamano
+
+    # Generar nombre automático del respaldo
+    nombre="backup_$(basename "$origen")_$(date +%Y%m%d_%H%M%S).tar.bz2"
+
+    # Crear respaldo comprimido
+    tar -cjf "$destino/$nombre" -C "$(dirname "$origen")" "$(basename "$origen")"
+
+    # Verificar si tar falló
+    if [[ $? -ne 0 ]]; then
+        msg_err "No se pudo crear el respaldo."
+        pausar
+        return
+    fi
+
+    # Verificar que el archivo exista
+    if [[ ! -f "$destino/$nombre" ]]; then
+        msg_err "El archivo de respaldo no fue creado."
+        pausar
+        return
+    fi
+
+    # Obtener tamaño del archivo
+    tamano=$(du -sh "$destino/$nombre" | awk '{print $1}')
+
+    msg_ok "Respaldo creado: $destino/$nombre (tamaño: $tamano)"
+
+    pausar
+}

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -61,6 +61,12 @@ respaldar_gzip() {
     # Solicitar carpeta origen
     read -rp "Carpeta origen: " origen
 
+    if [[ -z "$origen" ]]; then
+        msg_err "La ruta de origen no puede estar vacía."
+        pausar
+        return
+    fi
+
     # Validar existencia de carpeta origen
     if [[ ! -d "$origen" ]]; then
         msg_err "La carpeta '$origen' no existe."
@@ -71,6 +77,11 @@ respaldar_gzip() {
     # Solicitar carpeta destino
     read -rp "Ruta destino: " destino
 
+    if [[ -z "$destino" ]]; then
+        msg_err "La ruta de destino no puede estar vacía."
+        pausar
+        return
+    fi
 
     # Verificar si la carpeta destino existe
     if [[ ! -d "$destino" ]]; then


### PR DESCRIPTION
## Que hace este PR

Implementa el modulo de respaldo de informacion (`src/backup.sh`) para la Parte 2 del proyecto.

Permite crear respaldos comprimidos en formato:

.tar.gz usando Gzip
.tar.bz2 usando Bzip2



## Funciones implementadas

menu_respaldo
respaldar_gzip
respaldar_bzip2


## Caracteristicas

* Validacion de carpeta origen
* Validacion de carpeta destino
* Creacion automatica de directorios inexistentes
* Verificacion de permisos de escritura
* Generacion automatica de nombres con timestamp
* Verificacion de errores de tar
* Validacion de existencia del archivo generado
* Visualizacion del tamano del respaldo
* Uso correcto de helpers compartidos (msg_ok, msg_err, msg_warn, pausar, confirmar_accion)



## Como probar

bash -n src/backup.sh

sudo bash
cd /ruta/al/proyecto/root-admin-cli

source src/lib/utils.sh
source src/backup.sh

### Prueba Gzip

respaldar_gzip

Origen:
/etc

Destino:
/tmp

---

### Prueba Bzip2

respaldar_bzip2

Origen:
/var/log

Destino:
/tmp

Verificar:

tar -tjf /tmp/backup_log_*.tar.bz2 | head

---

## Casos de error probados

* Carpeta origen inexistente
* Carpeta destino inexistente
* Creacion automatica de carpeta destino
* Validacion de permisos de escritura
